### PR TITLE
fix auto flush buffer_limit

### DIFF
--- a/simplech/mock/http_client.py
+++ b/simplech/mock/http_client.py
@@ -99,7 +99,7 @@ class AsyncHttpClientMock(HttpClientMock):
 
     def process_select(self):
         super().process_select()
-        self.content = MockAsyncContent(self.mock_store.buff.getvalue())
+        self.content = MockAsyncContent(self.mock_store.buff.read())
 
     def _make_request(self, *args, **kwargs):
         return self


### PR DESCRIPTION
Hi all
Fixed behavior for push / flush on limit buffer overflow.
The problem was that `buffer_limit` was not being passed to the `Buffer` class. Which always resulted in `buffer_limit == 5000`

--------------
всем привет!
Исправил поведение для push/flush при переполнение буфера лимита.
Проблема заключалась в том что `buffer_limit` не передавался в класс `Buffer`. Это всегда приводило к `buffer_limit == 5000`